### PR TITLE
v0.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 ---
 require:
 - rubocop-rspec
-- rubocop-i18n
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.6'
   Include:
   - "./**/*.rb"
   Exclude:
@@ -18,16 +18,9 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText:
-  Enabled: false
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/**/*
-  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -40,10 +33,6 @@ Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/BracesAroundHashParameters:
-  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
-    See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -72,8 +61,12 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
-  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+Style/TrailingCommaInArrayLiteral:
+  Description: Prefer always trailing comma on array literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  Description: Prefer always trailing comma on hash literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
 Style/SymbolArray:
@@ -93,15 +86,9 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
-  Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
-  Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
-  Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,8 @@ jobs:
   fast_finish: true
   include:
     -
-      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file syntax lint metadata_lint"
       stage: static
-    -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+**Features**
+- The Business Rule in ServiceNow (for interacting with CD4PE) now automatically detects available MID Servers with a REST capability, and uses the first one available for outbound REST calls
+- Risk and Impact fields in the Change Request are automatically set in accordance to the Impact Analysis verdict
+- Now shows the name of the stage to promote toin the Change Request description, instead of the stage number
+
+**Bugfixes**
+- Now properly escapes special characters in commit descriptions, preventing an error when creating the Change Request
+
 ## Release 0.1.6
 
 **Bugfixes**

--- a/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
+++ b/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'uri'
+require 'cgi'
 require 'json'
 
 Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
@@ -9,31 +10,33 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
     required_param 'String',  :password
     required_param 'Hash',    :report
     required_param 'String',  :ia_url
-    required_param 'Integer', :promote_to_stage
+    required_param 'String',  :promote_to_stage_name
+    required_param 'Integer', :promote_to_stage_id
     required_param 'String',  :assignment_group
     required_param 'String',  :connection_alias
     required_param 'Boolean', :auto_create_ci
   end
 
-  def servicenow_change_request(endpoint, username, password, report, ia_url, promote_to_stage, assignment_group, connection_alias, auto_create_ci)
+  def servicenow_change_request(endpoint, username, password, report, ia_url, promote_to_stage_name, promote_to_stage_id, assignment_group, connection_alias, auto_create_ci)
     # Map facts to populate when auto-creating CI's
     fact_map = {
       # PuppetDB fact => ServiceNow CI field
-      'fqdn'                   => 'fqdn',
-      'domain'                 => 'dns_domain',
-      'serialnumber'           => 'serial_number',
+      'fqdn' => 'fqdn',
+      'domain' => 'dns_domain',
+      'serialnumber' => 'serial_number',
       'operatingsystemrelease' => 'os_version',
       'physicalprocessorcount' => 'cpu_count',
-      'processorcount'         => 'cpu_core_count',
-      'processors.models.0'    => 'cpu_type',
-      'memorysize_mb'          => 'ram',
-      'is_virtual'             => 'virtual',
-      'macaddress'             => 'mac_address',
+      'processorcount' => 'cpu_core_count',
+      'processors.models.0' => 'cpu_type',
+      'memorysize_mb' => 'ram',
+      'is_virtual' => 'virtual',
+      'macaddress' => 'mac_address',
     }
 
     # First, we need to create a new ServiceNow Change Request
-    description = "Puppet%20-%20Automated%20Change%20Request%20for%20promoting%20commit%20#{report['scm']['commit'][0, 7]}%20('#{report['scm']['description']}')%20to%20stage%20#{promote_to_stage}"
-    short_description = "Puppet%20Code%20-%20'#{report['scm']['description']}'%20to%20stage%20#{promote_to_stage}"
+    descr = "Puppet - Automated Change Request for promoting commit #{report['scm']['commit'][0, 7]} ('#{report['scm']['description']}') to stage '#{promote_to_stage_name}'"
+    description = CGI.escape(descr).gsub(%r{\+}, '%20')
+    short_description = CGI.escape("Puppet Code - '#{report['scm']['description']}' to stage '#{promote_to_stage_name}'").gsub(%r{\+}, '%20')
     request_uri = "#{endpoint}/api/sn_chg_rest/v1/change/normal?category=Puppet%20Code&short_description=#{short_description}&description=#{description}"
     request_response = make_request(request_uri, :post, username, password)
     raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{request_response.code} #{request_response.body}" unless request_response.is_a?(Net::HTTPSuccess)
@@ -135,7 +138,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
     closenotes['workspace']       = report['build']['owner']
     closenotes['repoName']        = report['build']['repo_name']
     closenotes['repoType']        = report['build']['repo_type']
-    closenotes['promoteToStage']  = promote_to_stage
+    closenotes['promoteToStage']  = promote_to_stage_id
     closenotes['scm_branch']      = report['scm']['branch']
     closenotes['connection']      = connection_alias
     bln_ia_safe_verdict = true
@@ -158,11 +161,15 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
 
     # Update Change Request with additional info, and start the approval process
     change_req_url = "#{endpoint}/api/sn_chg_rest/v1/change/normal/#{changereq['result']['sys_id']['value']}?state=assess"
-    payload = {
-      'risk_impact_analysis' => ia_url + "\n" + report['log'],
-      'assignment_group' => assignment_group_sys_id,
-      'close_notes' => closenotes.to_json,
-    }
+    payload = {}.tap do |data|
+      data[:risk_impact_analysis] = ia_url + "\n" + report['log'] # rubocop:disable Style/StringConcatenation
+      data[:assignment_group] = assignment_group_sys_id
+      data[:close_notes] = closenotes.to_json
+      data[:priority] = 3.0                           # 1.0 = Critical / 2.0 = High / 3.0 = Moderate / 4.0 = Low
+      data[:impact] = bln_ia_safe_verdict ? 3.0 : 2.0 # 1.0 = High / 2.0 = Medium / 3.0 = Low
+      data[:risk] = bln_ia_safe_verdict ? 4.0 : 2.0   # 2.0 = High / 3.0 = Medium / 4.0 = Low
+    end
+
     change_req_url_res = make_request(change_req_url, :patch, username, password, payload)
     raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{change_req_url_res.code} #{change_req_url_res.body}" unless change_req_url_res.is_a?(Net::HTTPSuccess)
   end
@@ -207,8 +214,6 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
       end
 
       case response
-      when Net::HTTPSuccess, Net::HTTPRedirection
-        return response
       when Net::HTTPInternalServerError
         if attempts < max_attempts # rubocop:disable Style/GuardClause
           Puppet.debug("Received #{response} error from #{uri.host}, attempting to retry. (Attempt #{attempts} of #{max_attempts})")
@@ -216,7 +221,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
         else
           raise Puppet::Error, "Received #{attempts} server error responses from the ServiceNow endpoint at #{uri.host}: #{response.code} #{response.body}"
         end
-      else
+      else # Covers Net::HTTPSuccess, Net::HTTPRedirection
         return response
       end
     end

--- a/files/deployments/plans/servicenow_integration.pp
+++ b/files/deployments/plans/servicenow_integration.pp
@@ -119,6 +119,7 @@ plan deployments::servicenow_integration(
     $snow_password,
     $report,
     $ia_url,
+    $stage_to_promote_to,
     $promote_stage_number,
     $assignment_group,
     $connection_alias,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-servicenow_change_requests",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "author": "puppetlabs",
   "summary": "Automate change requests in ServiceNow from CD4PE pipelines",
   "license": "Apache-2.0",

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -1,8 +1,5 @@
 # @summary
-#   Prepares ServiceNow for the Change Request integration by:
-#    - Ensuring a change category 'Puppet Code' exists
-#    - Ensuring a business rule 'Puppet - Promote code after approval' exists
-#    - Ensuring Connection Alias, Connection and Credentials objects exists
+#   Prepares ServiceNow for the Change Request integration by ensuring all necessary objects exist (Change Category, Business Rule, Connection & Credential objects)
 # 
 # @example
 #   bolt plan run servicenow_change_requests::prep_servicenow snow_endpoint=customer.service-now.com admin_user=admin admin_password=password cd4pe_endpoint=cd4pe.company.local
@@ -16,9 +13,9 @@
 # @param [String] cd4pe_endpoint
 #   FQDN of your CD4PE instance. Only specify the FQDN, do not specify https://
 # @param [Optional[Boolean]] cd4pe_https
-#   If your CD4PE instance is published over HTTP and not HTTPS, change this setting to false. Defaults to true
+#   If your CD4PE instance is published over HTTP and not HTTPS, change this setting to false
 # @param [Optional[Integer]] cd4pe_port
-#   If your CD4PE instance is published on a port other than 80(HTTP)/443(HTTPS), specify this setting.
+#   If your CD4PE instance is published on a port other than 80(HTTP)/443(HTTPS), specify this setting
 # @param [Optional[String]] connection_suffix
 #   If you are connecting multiple CD4PE instances to a single ServiceNow instance, specify a string here to identify this CD4PE instance
 # 

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -1,3 +1,27 @@
+# @summary
+#   Prepares ServiceNow for the Change Request integration by:
+#    - Ensuring a change category 'Puppet Code' exists
+#    - Ensuring a business rule 'Puppet - Promote code after approval' exists
+#    - Ensuring Connection Alias, Connection and Credentials objects exists
+# 
+# @example
+#   bolt plan run servicenow_change_requests::prep_servicenow snow_endpoint=customer.service-now.com admin_user=admin admin_password=password cd4pe_endpoint=cd4pe.company.local
+# 
+# @param [String] snow_endpoint
+#   FQDN of your ServiceNow instance. Only specify the FQDN, do not specify https://
+# @param [String] admin_user
+#   Username of the account in ServiceNow that has permissions to create objects
+# @param [String] admin_password
+#   Password of the account in ServiceNow that has permissions to create objects
+# @param [String] cd4pe_endpoint
+#   FQDN of your CD4PE instance. Only specify the FQDN, do not specify https://
+# @param [Optional[Boolean]] cd4pe_https
+#   If your CD4PE instance is published over HTTP and not HTTPS, change this setting to false. Defaults to true
+# @param [Optional[Integer]] cd4pe_port
+#   If your CD4PE instance is published on a port other than 80(HTTP)/443(HTTPS), specify this setting.
+# @param [Optional[String]] connection_suffix
+#   If you are connecting multiple CD4PE instances to a single ServiceNow instance, specify a string here to identify this CD4PE instance
+# 
 plan servicenow_change_requests::prep_servicenow(
   String $snow_endpoint,
   String $admin_user,

--- a/templates/business_rule_script.js.epp
+++ b/templates/business_rule_script.js.epp
@@ -16,6 +16,9 @@
 
             request.setHttpMethod(method);
             request.setEndpoint(endpoint);
+			if (midservers.length > 0) {
+				request.setMIDServer(midservers[0]);
+			}
             request.setRequestHeader('Content-Type', 'application/json');
             if (cookie != '') {
                 request.setRequestHeader('Cookie', cookie);
@@ -47,7 +50,11 @@
     }
 
     function PromotePuppetCode(){
-        gs.info('Puppet Code Promotion - Logging in to ' + endpoint);
+		if (midservers.length > 0) {
+			gs.info('Puppet Code Promotion - Using MID server: ' + midservers[0]);
+		}
+
+		gs.info('Puppet Code Promotion - Logging in to ' + endpoint);
         result = webrequest(endpoint + '/login', 'POST', postData, '');
 
         if (result.statuscode == 200) {
@@ -244,6 +251,23 @@
         endpoint    = PROTO + '://' + HOST;
     }
 
+	var mid_rest = new GlideRecord('ecc_agent_capability_m2m');
+	var midservers = [];
+
+	mid_rest.addQuery("capability.capability", "REST");
+	mid_rest.query();
+
+	while(mid_rest.next()) {
+		if(mid_rest.agent.status == "Up") {
+			gs.info("Puppet Code Promotion - Found online MID Server with REST capability: " + mid_rest.agent.name);
+			midservers.push(mid_rest.agent.name);
+		}
+	}
+
+	if (midservers.length == 0) {
+		gs.info('Puppet Code Promotion - No online MID Servers with REST capability found, not using a MID Server');
+	}
+	
     var username    = String(connectionInfo.getCredentialAttribute("user_name"));
     var password    = String(connectionInfo.getCredentialAttribute("password"));
     var workspace   = params_hash.workspace;


### PR DESCRIPTION
**Features**
- The Business Rule in ServiceNow (for interacting with CD4PE) now automatically detects available MID Servers with a REST capability, and uses the first one available for outbound REST calls
- Risk and Impact fields in the Change Request are automatically set in accordance to the Impact Analysis verdict
- Now shows the name of the stage to promote toin the Change Request description, instead of the stage number

**Bugfixes**
- Now properly escapes special characters in commit descriptions, preventing an error when creating the Change Request