### PR TITLE
v0.2.3 - CD4PE 4.5.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.3
+
+**Features**
+- Adds support for CD4PE 4.5.0
+
+Note: CD4PE 4.5.0 changes a certain API call that is used by the ServiceNow Business Rule ("Puppet - Promote code after approval") that this module installs. If you have used a previous version of this module to install the Business Rule, you are required to re-run the `servicenow_change_requests::prep_servicenow` plan that this module provides. The plan will automatically update the ServiceNow Business Rule to account for the API change.
+
+If you are running an older version of CD4PE than 4.5.0, you can still use this module, but you will need to specify an extra parameter to the `servicenow_change_requests::prep_servicenow` plan to ensure the older version of the Business Rule gets installed. To do so, set the `br_version` parameter of the plan to `0.2.2`. Once you upgrade to CD4PE 4.5.0, re-run the plan without specifying this parameter to upgrade the Business Rule.
+
+
+
 ## Release 0.2.2
 
 **Features**

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,6 +2,7 @@
 
 | Module version | Date released | PE min version | PE max version | CD4PE min version | CD4PE max version | ServiceNow min version | ServiceNow max version | Remarks |
 | -------------- | ------------- | -------------- | -------------- | ----------------- | ----------------- | ---------------------- | --------------------- | ------- |
+| 0.2.3 | 2021/04/09 | 2019.8.3 | 2021.1.0 | 4.5.0 | 4.5.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
 | 0.2.2 | 2021/04/09 | 2019.8.3 | 2021.0.0 | 3.13.4, 4.1.2 | 3.13.6, 4.4.1 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
 | 0.2.1 | 2021/03/17 | 2019.8.3 | 2021.0.0 | 3.13.2, 4.0.1 | 3.13.5, 4.4.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
 | 0.2.0 | 2021/02/11 |2019.8.1 | 2019.8.4 | 3.12.3, 4.0.0 | 3.13.4, 4.3.2 | Orlando | Paris |  |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 | Module version | Date released | PE min version | PE max version | CD4PE min version | CD4PE max version | ServiceNow min version | ServiceNow max version | Remarks |
 | -------------- | ------------- | -------------- | -------------- | ----------------- | ----------------- | ---------------------- | --------------------- | ------- |
-| 0.2.3 | 2021/04/09 | 2019.8.3 | 2021.1.0 | 4.5.0 | 4.5.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
+| 0.2.3 | 2021/04/09 | 2019.8.3 | 2021.1.0 | 3.13.4, 4.1.2 | 3.13.6, 4.5.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion. When running a version less than 4.5.0 of CD4PE, an extra br_version parameter must be specified for the prep_servicenow plan (see README) |
 | 0.2.2 | 2021/04/09 | 2019.8.3 | 2021.0.0 | 3.13.4, 4.1.2 | 3.13.6, 4.4.1 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
 | 0.2.1 | 2021/03/17 | 2019.8.3 | 2021.0.0 | 3.13.2, 4.0.1 | 3.13.5, 4.4.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
 | 0.2.0 | 2021/02/11 |2019.8.1 | 2019.8.4 | 3.12.3, 4.0.0 | 3.13.4, 4.3.2 | Orlando | Paris |  |

--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ For example, to configure the ServiceNow instance `https://dev-365937.service-no
 * `admin_password = <password>`
 * `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
 
-
 #### Optional plan parameters
+
+If you are running a CD4PE version lower than 4.5.0, you will need to set the `br_version` parameter to ensure a compatible version of the Business Rule gets installed in ServiceNow:
+* `br_version = 0.2.2`
+
+Omit this parameter when you are running CD4PE 4.5.0 or above, which will install version 0.2.3 of the Business Rule, which is compatible with CD4PE 4.5.0.
 
 The optional parameters `cd4pe_https` and `cd4pe_port` can be used to connect to a CD4PE server on a different port, or via http. For example, to configure the ServiceNow instance `https://dev-365937.service-now.com` to integrate with a CD4PE server at `http://puppet-cd4pe.mycompany.com:8080`, specify the parameters as follows:
 * `snow_endpoint = dev-365937.service-now.com`
@@ -62,7 +66,7 @@ The optional parameters `cd4pe_https` and `cd4pe_port` can be used to connect to
 * `cd4pe_https = false`
 * `cd4pe_port = 8080`
 
-Finally the optional parameter `connection_suffix` can be used to integrate multiple CD4PE installations with a single ServiceNow instance. By default, the plan will create a `Puppet_Code` Connection Alias in ServiceNow, linked to a `Puppet Code Connection` and a `Puppet Code Credential`. This is great for when you have a single CD4PE installation. If you have 1 CD4PE installation, you don't need to specify the `connection_suffix` parameter.
+The optional parameter `connection_suffix` can be used to integrate multiple CD4PE installations with a single ServiceNow instance. By default, the plan will create a `Puppet_Code` Connection Alias in ServiceNow, linked to a `Puppet Code Connection` and a `Puppet Code Credential`. This is great for when you have a single CD4PE installation. If you have 1 CD4PE installation, you don't need to specify the `connection_suffix` parameter.
 
 To handle the multiple CD4PE installations for ServiceNow to interact with, a separate set of connections & credentials needs to be created in ServiceNow for each CD4PE instance. To let the plan do so, specify an appropriate suffix for this parameter. For example, to setup the integration for a secondary CD4PE installation used for "QA", specify `connection_suffix = QA`. This will create the following in ServiceNow:
 * A `Puppet_Code_QA` Connection Alias

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-servicenow_change_requests",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "puppetlabs",
   "summary": "Automate change requests in ServiceNow from CD4PE pipelines",
   "license": "Apache-2.0",

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -158,20 +158,18 @@ plan servicenow_change_requests::prep_servicenow(
     out::message("Business rule 'Puppet - Promote code after approval' successfully added.")
   }
   else {
-    if $rule_check_result['body'][0]['script'] =~ /\\r\\n\/\/ Version: (\d.\d.\d)\\r\\n/ {
-      out::message('Existing version found')
-      out::message($1)
-      out::message($br_version)
+    out::message("Business rule 'Puppet - Promote code after approval' exists, checking version...")
+    if $rule_check_result['body'][0]['script'] =~ /\/\/ BR_Version: (\d.\d.\d)/ {
       $update_rule = versioncmp($1, $br_version) ? {
         0 => false,
         1 => false,
         -1 => true
       }
     } else {
-      out::message('No existing version found')
       $update_rule = true
     }
     if $update_rule {
+      out::message("Business rule 'Puppet - Promote code after approval' is outdated and will be updated...")
       $rule_script = epp("servicenow_change_requests/${br_version}/business_rule_script.js")
       $updated_rule = { 'script' => $rule_script }
       $rule_uri = "${_snow_endpoint}/api/now/table/sys_script/${rule_check_result['body'][0]['sys_id']}"
@@ -179,7 +177,7 @@ plan servicenow_change_requests::prep_servicenow(
       unless $rule_result['code'] == 200 {
         fail("Unable to update business rule 'Puppet - Promote code after approval'! Got error ${rule_result['code']} with message ${rule_result['body']}") # lint:ignore:140chars
       }
-      out::message("Business rule 'Puppet - Promote code after approval' successfully update to version ${br_version}.")
+      out::message("Business rule 'Puppet - Promote code after approval' successfully updated to version ${br_version}.")
     } else {
       out::message("Business rule 'Puppet - Promote code after approval' already present and up to date, nothing to do.")
     }

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -33,6 +33,7 @@ plan servicenow_change_requests::prep_servicenow(
   Optional[String] $connection_suffix = undef,
   Optional[String] $proxy_host = undef,
   Optional[Integer] $proxy_port = undef,
+  Optional[String] $br_version = '0.2.3'
 ){
   # Parse flexible parameters
   $_snow_endpoint = $snow_endpoint[0,8] ? {
@@ -116,38 +117,38 @@ plan servicenow_change_requests::prep_servicenow(
   unless $rule_check_result['body'].size == 1 {
     # Add 'Puppet Code Promotion' business rule
     out::message("Business rule 'Puppet - Promote code after approval' does not exist, adding rule...")
-    $rule_script = epp('servicenow_change_requests/business_rule_script.js')
+    $rule_script = epp("servicenow_change_requests/${br_version}/business_rule_script.js")
     $new_rule = {
-      client_callable   => 'false',
-      template          => '',
-      access            => 'package_private',
-      action_insert     => 'false',
-      action_update     => 'true',
-      advanced          => 'true',
-      action_delete     => 'false',
-      change_fields     => 'false',
-      description       => '',
-      action_query      => 'false',
-      when              => 'async',
-      is_rest           => 'false',
-      rest_method_text  => '',
-      rest_service_text => '',
-      order             => '100',
-      rest_method       => '',
-      rest_service      => '',
-      add_message       => 'false',
-      active            => 'true',
-      collection        => 'change_request',
-      message           => '',
-      priority          => '100',
-      script            => $rule_script,
-      abort_action      => 'false',
-      execute_function  => 'false',
-      filter_condition  => 'stateCHANGESTO-1^category=Puppet Code^NQcategory=Puppet Code^state=-1^on_holdCHANGESTOfalse^EQ',
-      condition         => '',
-      rest_variables    => '',
-      name              => 'Puppet - Promote code after approval',
-      role_conditions   => '',
+      'client_callable'   => 'false',
+      'template'          => '',
+      'access'            => 'package_private',
+      'action_insert'     => 'false',
+      'action_update'     => 'true',
+      'advanced'          => 'true',
+      'action_delete'     => 'false',
+      'change_fields'     => 'false',
+      'description'       => '',
+      'action_query'      => 'false',
+      'when'              => 'async',
+      'is_rest'           => 'false',
+      'rest_method_text'  => '',
+      'rest_service_text' => '',
+      'order'             => '100',
+      'rest_method'       => '',
+      'rest_service'      => '',
+      'add_message'       => 'false',
+      'active'            => 'true',
+      'collection'        => 'change_request',
+      'message'           => '',
+      'priority'          => '100',
+      'script'            => $rule_script,
+      'abort_action'      => 'false',
+      'execute_function'  => 'false',
+      'filter_condition'  => 'stateCHANGESTO-1^category=Puppet Code^NQcategory=Puppet Code^state=-1^on_holdCHANGESTOfalse^EQ',
+      'condition'         => '',
+      'rest_variables'    => '',
+      'name'              => 'Puppet - Promote code after approval',
+      'role_conditions'   => '',
     }
     $new_rule_uri = "${_snow_endpoint}/api/now/table/sys_script"
     $new_rule_result = servicenow_change_requests::make_request($new_rule_uri, 'post', $proxy, $admin_user, $admin_password, $new_rule)
@@ -157,7 +158,27 @@ plan servicenow_change_requests::prep_servicenow(
     out::message("Business rule 'Puppet - Promote code after approval' successfully added.")
   }
   else {
-    out::message("Business rule 'Puppet - Promote code after approval' already present, nothing to do.")
+    if $rule_check_result['body']['result'][0]['script'] =~ /\\r\\n\/\/ Version: (\d.\d.\d)\\r\\n/ {
+      $update_rule = versioncmp($1, $br_version) ? {
+        0 => false,
+        1 => false,
+        -1 => true
+      }
+    } else {
+      $update_rule = true
+    }
+    if $update_rule {
+      $rule_script = epp("servicenow_change_requests/${br_version}/business_rule_script.js")
+      $updated_rule = { 'script' => $rule_script }
+      $rule_uri = "${_snow_endpoint}/api/now/table/sys_script/${rule_check_result['body']['result'][0]['sys_id']}"
+      $rule_result = servicenow_change_requests::make_request($rule_uri, 'patch', $proxy, $admin_user, $admin_password, $updated_rule)
+      unless $rule_result['code'] == 200 {
+        fail("Unable to update business rule 'Puppet - Promote code after approval'! Got error ${rule_result['code']} with message ${rule_result['body']}") # lint:ignore:140chars
+      }
+      out::message("Business rule 'Puppet - Promote code after approval' successfully update to version ${br_version}.")
+    } else {
+      out::message("Business rule 'Puppet - Promote code after approval' already present and up to date, nothing to do.")
+    }
   }
 
   # Determine naming of connection details

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -158,7 +158,7 @@ plan servicenow_change_requests::prep_servicenow(
     out::message("Business rule 'Puppet - Promote code after approval' successfully added.")
   }
   else {
-    if $rule_check_result['body']['result'][0]['script'] =~ /\\r\\n\/\/ Version: (\d.\d.\d)\\r\\n/ {
+    if $rule_check_result['body'][0]['script'] =~ /\\r\\n\/\/ Version: (\d.\d.\d)\\r\\n/ {
       $update_rule = versioncmp($1, $br_version) ? {
         0 => false,
         1 => false,
@@ -170,7 +170,7 @@ plan servicenow_change_requests::prep_servicenow(
     if $update_rule {
       $rule_script = epp("servicenow_change_requests/${br_version}/business_rule_script.js")
       $updated_rule = { 'script' => $rule_script }
-      $rule_uri = "${_snow_endpoint}/api/now/table/sys_script/${rule_check_result['body']['result'][0]['sys_id']}"
+      $rule_uri = "${_snow_endpoint}/api/now/table/sys_script/${rule_check_result['body'][0]['sys_id']}"
       $rule_result = servicenow_change_requests::make_request($rule_uri, 'patch', $proxy, $admin_user, $admin_password, $updated_rule)
       unless $rule_result['code'] == 200 {
         fail("Unable to update business rule 'Puppet - Promote code after approval'! Got error ${rule_result['code']} with message ${rule_result['body']}") # lint:ignore:140chars

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -159,12 +159,16 @@ plan servicenow_change_requests::prep_servicenow(
   }
   else {
     if $rule_check_result['body'][0]['script'] =~ /\\r\\n\/\/ Version: (\d.\d.\d)\\r\\n/ {
+      out::message('Existing version found')
+      out::message($1)
+      out::message($br_version)
       $update_rule = versioncmp($1, $br_version) ? {
         0 => false,
         1 => false,
         -1 => true
       }
     } else {
+      out::message('No existing version found')
       $update_rule = true
     }
     if $update_rule {

--- a/templates/0.2.2/business_rule_script.js.epp
+++ b/templates/0.2.2/business_rule_script.js.epp
@@ -1,5 +1,5 @@
 (function executeRule(current, previous /*null when async*/) {
-
+// Version: 0.2.2
     function GetIDValue(table, displayValue) {
 		var rec = new GlideRecord(table);
 		var dn = gs.getDisplayColumn(table);

--- a/templates/0.2.2/business_rule_script.js.epp
+++ b/templates/0.2.2/business_rule_script.js.epp
@@ -1,5 +1,5 @@
 (function executeRule(current, previous /*null when async*/) {
-// Version: 0.2.2
+// BR_Version: 0.2.2
     function GetIDValue(table, displayValue) {
 		var rec = new GlideRecord(table);
 		var dn = gs.getDisplayColumn(table);

--- a/templates/0.2.3/business_rule_script.js.epp
+++ b/templates/0.2.3/business_rule_script.js.epp
@@ -1,5 +1,5 @@
 (function executeRule(current, previous /*null when async*/) {
-// Version: 0.2.3
+// BR_Version: 0.2.3
     function GetIDValue(table, displayValue) {
 		var rec = new GlideRecord(table);
 		var dn = gs.getDisplayColumn(table);

--- a/templates/0.2.3/business_rule_script.js.epp
+++ b/templates/0.2.3/business_rule_script.js.epp
@@ -1,0 +1,334 @@
+(function executeRule(current, previous /*null when async*/) {
+// Version: 0.2.3
+    function GetIDValue(table, displayValue) {
+		var rec = new GlideRecord(table);
+		var dn = gs.getDisplayColumn(table);
+
+		if (rec.get(dn, displayValue))
+			return rec.sys_id;
+		else
+			return null;
+	}
+
+    function webrequest(endpoint,method,payload,cookie) {
+        try {
+            var request = new sn_ws.RESTMessageV2();
+
+            request.setHttpMethod(method);
+            request.setEndpoint(endpoint);
+			if (midservers.length > 0) {
+				request.setMIDServer(midservers[0]);
+			}
+            request.setRequestHeader('Content-Type', 'application/json');
+            if (cookie != '') {
+                request.setRequestHeader('Cookie', cookie);
+            }
+            if (method == 'POST' && payload != '') {
+                request.setRequestBody(JSON.stringify(payload)); 
+            }
+            
+            var response = request.execute();
+            var httpResponseStatus = response.getStatusCode();
+            var httpResponseHeaders = response.getHeaders();
+            var httpResponseBody = response.getBody();
+
+            gs.info('Puppet Code Promotion - http response status_code: ' + httpResponseStatus);
+
+            var res = {
+                statuscode: httpResponseStatus,
+                headers: httpResponseHeaders,
+                body: httpResponseBody
+            };
+
+            // Return results
+            return res;
+        }
+        catch (ex) {
+            var message = ex.getMessage();
+            gs.error(message);
+        }
+    }
+
+    function PromotePuppetCode(){
+		if (midservers.length > 0) {
+			gs.info('Puppet Code Promotion - Using MID server: ' + midservers[0]);
+		}
+
+		gs.info('Puppet Code Promotion - Logging in to ' + endpoint);
+        result = webrequest(endpoint + '/cd4pe/login', 'POST', postData, '');
+
+        if (result.statuscode == 200) {
+            gs.info('Puppet Code Promotion - Logged in successfully');
+            gs.info('Puppet Code Promotion - Login response message body: ' + result.body);
+        }
+        else {
+            gs.error('Puppet Code Promotion - Unable to login! Received statuscode ' + result.statuscode);
+            gs.error('Puppet Code Promotion - Login error message body: ' + result.body);
+            return false;
+        }
+
+        // Set cookie
+        if (result.headers["Set-Cookie"]){
+            cookie = result.headers["Set-Cookie"];
+        } else {
+            cookie = result.headers["set-cookie"];
+        }
+
+        // Set base payload for pipeline promotion
+        postData.op = 'PipelinePromote';
+        postData.content = {
+            'pipelineId': pipeline,
+            'branch': branch,
+            'sha': sha,
+            'stageNumber': stagenumber,
+            'commitMsg': 'ServiceNow: Promote ' + sha.substring(0,7) + ' ("' + message + '") of branch ' + branch + ' to stage ' + stagenumber
+        };
+
+        // Add repo name & type in payload
+        if (repotype == 'CONTROL_REPO') {
+            postData.content['controlRepoName'] = repo;
+        } else {
+            postData.content['moduleName'] = repo;
+        }
+
+        gs.info('Puppet Code Promotion - Promoting commit ' + sha.substring(0,7) + ' ("' + message + '") of branch ' + branch + ' to stage ' + stagenumber + ' in pipeline');
+        result = webrequest(endpoint + '/' + workspace + '/ajax', 'POST', postData, cookie);
+
+        if (result.statuscode == 200 && result.body != '[]') {
+            gs.info('Puppet Code Promotion - Pipeline promoted successfully!');
+            gs.info('Puppet Code Promotion - Promotion response message body: ' + result.body);
+            current.work_notes = 'Puppet code pipeline promoted successfully, checking if approvals are needed...';
+            current.update();
+        }
+        else {
+            gs.error('Puppet Code Promotion - Unable to promote pipeline! Received statuscode ' + result.statuscode);
+            current.work_notes = 'Puppet code pipeline could not be promoted! Received statuscode ' + result.statuscode;
+            current.update();
+            if (result.body == '[]') {
+                gs.error('Puppet Code Promotion - The combination of pipelineId, controlRepoName, branch, sha and stageNumber was invalid.');
+            } else {
+                gs.error('Puppet Code Promotion - Error message body: ' + result.body);
+            }
+            return false;
+        }
+
+        // Grab deploymentId from result body
+        var arrDeploymentId = [];
+        JSON.parse(result.body).forEach(function(item) {
+            if (item.type == 'DEPLOYMENT') {
+                arrDeploymentId.push(item.id.split(':')[1]);
+            }
+        });
+
+        if (arrDeploymentId.length) {
+            gs.info('Puppet Code Promotion - Promoted stage(s) contain one or more deployments, checking for approval status');
+        } else {
+            gs.info('Puppet Code Promotion - Promoted stage(s) do not contain any deployments, nothing to do');
+            current.work_notes = 'Promoted pipeline stages do not contain any deployments, nothing more to do';
+            current.update();
+            return true;
+        }
+
+        // Process each deployment in order
+        blnOk = true;
+        arrDeploymentId.forEach(function(deploy) {
+            if (blnOk) {
+                // Wait for deploy to reach a status requiring action
+                var timesPolled = 1;
+                var keepLooping = true;
+				gs.sleep(5000);
+                do {
+                    result = webrequest(endpoint + '/' + workspace + '/ajax?op=GetDeployment&id=' + deploy, 'GET', '', cookie);
+					if (result.statuscode == 200) {
+						deploymentState = JSON.parse(result.body).deploymentState;
+						gs.info('Puppet Code Promotion - Checking deployment ' + deploy + ' status (' + timesPolled++ + '): ' + deploymentState);
+						if (deploymentState == 'QUEUED' || deploymentState == 'RUNNING') {
+							gs.sleep(3000);
+							keepLooping = true;
+						}
+						else {
+							keepLooping = false;
+						}
+					}
+					else {
+						gs.error('Puppet Code Promotion - Unable to check deployment ' + deploy + '! Received statuscode ' + result.statusCode);
+						gs.error('Puppet Code Promotion - Message body: ' + result.body);
+						current.work_notes = 'Puppet Code Deployment ' + deploy + ': Unable to check deployment';
+						current.update();
+						blnOk = false;
+						keepLooping = false;
+						return;
+					}
+                } while (keepLooping && timesPolled < 4800);
+
+				gs.info('Puppet Code Promotion - Deployment ' + deploy + ' reached status: ' + deploymentState);
+
+                if (deploymentState == 'PENDING_APPROVAL') {
+                    gs.info('Puppet Code Promotion - Deployment ' + deploy + ' requires approval, proceeding...');
+                } else {
+                    gs.info('Puppet Code Promotion - Deployment ' + deploy + ' did not require approval, nothing more to do.');
+                    return;
+                }
+
+                // Set payload for pipeline promotion
+                postData.op = 'SetDeploymentApproval';
+                postData.content = {
+                    'approvalDecision': 'APPROVED',
+                    'deploymentType': repotype,
+                    'deploymentId': deploy
+                };
+
+                if (repotype == 'CONTROL_REPO') {
+                    postData.content['deploymentType'] = 'CONTROL_REPOSITORY';
+                }
+
+                result = webrequest(endpoint + '/' + workspace + '/ajax', 'POST', postData, cookie);
+
+                if (result.statuscode == 200) {
+                    gs.info('Puppet Code Promotion - Deployment ' + deploy + ' approved successfully!');
+                    gs.info('Puppet Code Promotion - Deployment ' + deploy + ' response message body: ' + result.body);
+                    current.work_notes = 'Puppet Code Deployment ' + deploy + ' approved successfully';
+                    current.update();
+                }
+                else {
+                    gs.error('Puppet Code Promotion - Unable to approve deployment ' + deploy + '! Received statuscode ' + result.statusCode);
+                    gs.error('Puppet Code Promotion - Message body: ' + result.body);
+                    current.work_notes = 'Puppet Code Deployment ' + deploy + ': Unable to approve deployment';
+                    current.update();
+                    blnOk = false;
+                    return;
+                }
+
+                // Wait for deployment to complete (or fail)
+                timesPolled = 1;
+                keepLooping = true;
+                do {
+                    result = webrequest(endpoint + '/' + workspace + '/ajax?op=GetDeployment&id=' + deploy, 'GET', '', cookie);
+                    deploymentState = JSON.parse(result.body).deploymentState;
+                    gs.info('Puppet Code Promotion - Checking deployment ' + deploy + ' status (' + timesPolled++ + '): ' + deploymentState);
+                    if (deploymentState == 'APPROVED' || deploymentState == 'RUNNING') {
+                        keepLooping = true;
+                    }
+                    else {
+                        keepLooping = false;
+                    }
+                    gs.sleep(3000);
+                } while (keepLooping && timesPolled < 4800);
+
+                gs.info('Puppet Code Promotion - Deployment ' + deploy + ' reached status: ' + deploymentState);
+
+                if (deploymentState == 'DONE') {
+                    gs.info('Puppet Code Promotion - Deployment ' + deploy + ' completed successfully');
+                    current.work_notes = 'Puppet Code Deployment ' + deploy + ' completed successfully';
+                    current.update();
+                    return;
+                } else {
+                    gs.error('Puppet Code Promotion - Deployment ' + deploy + ' ended with status: ' + deploymentState);
+                    current.work_notes = 'Puppet Code Deployment ' + deploy + ' ended with status: ' + deploymentState;
+                    current.update();
+                    blnOk = false;
+                    return;
+                }
+            }
+        });
+        return blnOk;
+    }
+
+    var params_hash = JSON.parse(current.close_notes);
+    var aliasID = GetIDValue('sys_alias', params_hash.connection);
+
+    var provider = new sn_cc.ConnectionInfoProvider();
+    var connectionInfo = provider.getConnectionInfo(aliasID);
+
+    var HOST        = String(connectionInfo.getAttribute("host"));
+    var PORT        = String(connectionInfo.getAttribute("port"));
+    var PROTO       = String(connectionInfo.getAttribute("protocol")); 
+
+    var endpoint;
+    if (PORT) {
+        endpoint    = PROTO + '://' + HOST + ':' + PORT;
+    } else {
+        endpoint    = PROTO + '://' + HOST;
+    }
+
+	var mid_rest = new GlideRecord('ecc_agent_capability_m2m');
+	var midservers = [];
+
+	mid_rest.addQuery("capability.capability", "REST");
+	mid_rest.query();
+
+	while(mid_rest.next()) {
+		if(mid_rest.agent.status == "Up") {
+			gs.info("Puppet Code Promotion - Found online MID Server with REST capability: " + mid_rest.agent.name);
+			midservers.push(mid_rest.agent.name);
+		}
+	}
+
+	if (midservers.length == 0) {
+		gs.info('Puppet Code Promotion - No online MID Servers with REST capability found, not using a MID Server');
+	}
+	
+    var username    = String(connectionInfo.getCredentialAttribute("user_name"));
+    var password    = String(connectionInfo.getCredentialAttribute("password"));
+    var workspace   = params_hash.workspace;
+    var pipeline    = params_hash.pipelineId;
+    var repo        = params_hash.repoName;
+    var repotype    = params_hash.repoType;
+    var branch      = params_hash.scm_branch;
+    var sha         = params_hash.commitSHA;
+    var message     = trim(params_hash.commitMsg);
+    var stagenumber = params_hash.promoteToStage;
+    var result;
+    var cookie;
+    var postData = {
+        op: 'PfiLogin',
+        content: {
+            email: username,
+            passwd: password
+        }
+    };
+
+    // Add work note
+    current.work_notes = 'Promoting commit ' + sha.substring(0,7) + ' ("' + message + '") of branch ' + branch + ' to stage ' + stagenumber + ' in the background...';
+    current.update();
+
+    // Query all active change tasks of change
+    var INPROGRESS = 2;
+    var CLOSED = 3;
+    var childChangeTask = new GlideRecord('change_task');
+    childChangeTask.addQuery('change_request',current.getValue('sys_id'));
+    childChangeTask.addActiveQuery();
+    childChangeTask.query();
+
+    // Loop through all changes and update
+    while (childChangeTask .next()){
+        childChangeTask.state = INPROGRESS;
+        childChangeTask.update();
+    }
+
+    // Promote Puppet code
+    var promote_success = PromotePuppetCode();
+
+    // Finish up
+    if (promote_success) {
+        current.work_notes = 'Finished promoting Puppet code. Closing Change Tasks...';
+        current.update();
+
+        childChangeTask.query();
+        // Loop through all changes and update
+        while (childChangeTask .next()){
+            childChangeTask.state = CLOSED;
+            childChangeTask.update();
+        }
+
+        current.work_notes = 'Finished closing Change Tasks, setting Close Code to Successful...';
+        current.update();
+        current.close_code = 'successful';
+        current.update();
+    }
+    else {
+        current.work_notes = 'Errors occurred while promoting Puppet code. Consult the logs for more information.';
+        current.update();
+    }
+
+})(current, previous);


### PR DESCRIPTION
This PR adds support for CD4PE 4.5.x, which changes the API login endpoint from `/login` to `/cd4pe/login`. This requires an update to the Business Rule in ServiceNow.

The `prep_servicenow` plan has been updated to automatically detect the ServiceNow Business Rule needs to be updated, and then proceeds to patch the Business Rule. An extra `br_version` parameter has been added to the plan to enable installing the previous version of the Business Rule for compatibility with older versions of CD4PE. See the README and CHANGELOG for more information.