### PR TITLE
OAuth support and Sensitive types for credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.3.0
+
+**Features**
+- Adds support for OAuth authentication against ServiceNow
+- Uses the Sensitive datatype for password & OAuth token inputs, which will mask the input in PE and CD4PE
+- Removes official support for CD4PE 3.x
+
 ## Release 0.2.3
 
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 **Features**
 - Adds support for OAuth authentication against ServiceNow
 - Uses the Sensitive datatype for password & OAuth token inputs, which will mask the input in PE and CD4PE
+- Adds official support for ServiceNow Rome
 - Removes official support for CD4PE 3.x
 
 ## Release 0.2.3

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,6 +2,7 @@
 
 | Module version | Date released | PE min version | PE max version | CD4PE min version | CD4PE max version | ServiceNow min version | ServiceNow max version | Remarks |
 | -------------- | ------------- | -------------- | -------------- | ----------------- | ----------------- | ---------------------- | --------------------- | ------- |
+| 0.3.0 | 2021/08/13 | 2019.8.5 | 2021.1.0 | 4.8.0 | 4.8.0 | Paris | Rome | Recommended to use Rome over Quebec |
 | 0.2.3 | 2021/04/09 | 2019.8.3 | 2021.1.0 | 3.13.4, 4.1.2 | 3.13.6, 4.5.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion. When running a version less than 4.5.0 of CD4PE, an extra br_version parameter must be specified for the prep_servicenow plan (see README) |
 | 0.2.2 | 2021/04/09 | 2019.8.3 | 2021.0.0 | 3.13.4, 4.1.2 | 3.13.6, 4.4.1 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |
 | 0.2.1 | 2021/03/17 | 2019.8.3 | 2021.0.0 | 3.13.2, 4.0.1 | 3.13.5, 4.4.0 | Orlando | Quebec | Slight bug in ServiceNow Quebec, where it creates 4 canceled change tasks upon completion of code promotion |

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ Finally, this README provides the instructions for getting the integration up & 
 ### System Requirements & Compatibility
 
 These are the requirements for the latest version of the module, see the [Compatibility matrix](https://github.com/puppetlabs/puppetlabs-servicenow_change_requests/blob/master/COMPATIBILITY.md) for more specific details.
-* Puppet Enterprise 2019.8.3 or higher
-* CD4PE 3.13.4 or higher
-* ServiceNow Orlando or higher
-
+* Puppet Enterprise 2019.8.5 or higher
+* CD4PE 4.8.0 or higher
+* ServiceNow Paris or higher
 
 ### Preparing ServiceNow
 
@@ -39,17 +38,25 @@ To ensure we can automate change requests, some things need to be added to Servi
 
 A single plan takes care of setting this up. To run the plan, go to the `Plans` section in the left navigation bar in Puppet Enterprise. In the "Run a plan" screen, select the `servicenow_change_requests::prep_servicenow` from the Plan dropdown list. If the plan is not listed, ensure that this module has been added to the Puppetfile of your control repo, and that you have performed a code deployment to your production environment.
 
-The plan requires 4 parameters, and has 3 more optional parameters for specific use cases. The 4 required parameters are:
-* `snow_endpoint`: The reachable FQDN of the ServiceNow instance (just the name is sufficient)
-* `admin_user`: The username of an administrator in ServiceNow, to make the necessary changes
-* `admin_password`: The password of the specified admin_user
+The plan requires 2 parameters + authentication info, and has 3 more optional parameters for specific use cases. The 2 required parameters are:
+* `snow_endpoint`:  The reachable FQDN of the ServiceNow instance (just the name is sufficient)
 * `cd4pe_endpoint`: The publicly reachable FQDN of the CD4PE server (just the name, not the full URL)
 
-For example, to configure the ServiceNow instance `https://dev-365937.service-now.com` to integrate with a CD4PE server at `https://puppet-cd4pe.mycompany.com`, specify the parameters as follows:
-* `snow_endpoint = dev-365937.service-now.com`
-* `admin_user = admin`
-* `admin_password = <password>`
+For authentication info, either a username + password must be set, or a valid OAuth token can be used:
+* `admin_user`:     The username of an administrator in ServiceNow, to make the necessary changes
+* `admin_password`: The password of the specified admin_user
+* `oauth_token`:    An OAuth token for accessing ServiceNow, instead of using username + password
+
+For example, to configure the ServiceNow instance `https://dev365937.service-now.com` to integrate with a CD4PE server at `https://puppet-cd4pe.mycompany.com`, specify the parameters as follows:
+* `snow_endpoint  = dev365937.service-now.com`
 * `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
+* `admin_user     = admin`
+* `admin_password = <password>`
+
+or, with an OAuth token:
+* `snow_endpoint  = dev365937.service-now.com`
+* `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
+* `oauth_token    = <token>`
 
 #### Optional plan parameters
 
@@ -58,13 +65,13 @@ If you are running a CD4PE version lower than 4.5.0, you will need to set the `b
 
 Omit this parameter when you are running CD4PE 4.5.0 or above, which will install version 0.2.3 of the Business Rule, which is compatible with CD4PE 4.5.0.
 
-The optional parameters `cd4pe_https` and `cd4pe_port` can be used to connect to a CD4PE server on a different port, or via http. For example, to configure the ServiceNow instance `https://dev-365937.service-now.com` to integrate with a CD4PE server at `http://puppet-cd4pe.mycompany.com:8080`, specify the parameters as follows:
-* `snow_endpoint = dev-365937.service-now.com`
-* `admin_user = admin`
+The optional parameters `cd4pe_https` and `cd4pe_port` can be used to connect to a CD4PE server on a different port, or via http. For example, to configure the ServiceNow instance `https://dev365937.service-now.com` to integrate with a CD4PE server at `http://puppet-cd4pe.mycompany.com:8080`, specify the parameters as follows:
+* `snow_endpoint  = dev365937.service-now.com`
+* `admin_user     = admin`
 * `admin_password = <password>`
 * `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
-* `cd4pe_https = false`
-* `cd4pe_port = 8080`
+* `cd4pe_https    = false`
+* `cd4pe_port     = 8080`
 
 The optional parameter `connection_suffix` can be used to integrate multiple CD4PE installations with a single ServiceNow instance. By default, the plan will create a `Puppet_Code` Connection Alias in ServiceNow, linked to a `Puppet Code Connection` and a `Puppet Code Credential`. This is great for when you have a single CD4PE installation. If you have 1 CD4PE installation, you don't need to specify the `connection_suffix` parameter.
 
@@ -119,6 +126,7 @@ Once the custom deployment policy is available, add it to your `master` pipeline
    * `snow_endpoint`: the FQDN of your ServiceNow instance (e.g. `dev-365937.service-now.com`)
    * `snow_username`: the username to authenticate with ServiceNow (e.g. `admin`)
    * `snow_password`: the password to authenticate with ServiceNow (e.g. `P@ssw0rd!`)
+   * `snow_oauth_token`: an OAuth token for ServiceNow, instead of using username + password (if you set an OAuth token, it will be used instead of username + password)
    * `stage_to_promote_to`: the name of the stage to promote to, when approved (e.g. `Deploy to Production`)
 7. If desired, set (some of the) optional parameters for the policy:
    * `max_changes_per_node`: how many resources per node may change before CD4PE recommends this code change warrants more scrutiny (defaults to `10`)

--- a/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
+++ b/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
@@ -5,18 +5,18 @@ require 'json'
 
 Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
   dispatch :servicenow_change_request do
-    required_param 'String',            :endpoint
-    required_param 'Hash',              :proxy
-    required_param 'String',            :username
-    required_param 'Sensitive[String]', :password
-    required_param 'Sensitive[String]', :oauth_token
-    required_param 'Hash',              :report
-    required_param 'String',            :ia_url
-    required_param 'String',            :promote_to_stage_name
-    required_param 'Integer',           :promote_to_stage_id
-    required_param 'String',            :assignment_group
-    required_param 'String',            :connection_alias
-    required_param 'Boolean',           :auto_create_ci
+    required_param 'String',    :endpoint
+    required_param 'Hash',      :proxy
+    required_param 'String',    :username
+    required_param 'Sensitive', :password
+    required_param 'Sensitive', :oauth_token
+    required_param 'Hash',      :report
+    required_param 'String',    :ia_url
+    required_param 'String',    :promote_to_stage_name
+    required_param 'Integer',   :promote_to_stage_id
+    required_param 'String',    :assignment_group
+    required_param 'String',    :connection_alias
+    required_param 'Boolean',   :auto_create_ci
   end
 
   def servicenow_change_request(endpoint, proxy, username, password, oauth_token, report, ia_url, promote_to_stage_name, promote_to_stage_id, assignment_group, connection_alias, auto_create_ci)
@@ -153,7 +153,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
 
     # Get sys_id of given assignment_group
     assignment_group_url = "#{endpoint}/api/now/table/sys_user_group?sysparm_query=name=#{assignment_group}"
-    assignment_group_response = make_request(assignment_group_url, :get, proxy, username, oauth_token, password)
+    assignment_group_response = make_request(assignment_group_url, :get, proxy, username, password, oauth_token)
     raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{assignment_group_response.code} #{assignment_group_response.body}" unless assignment_group_response.is_a?(Net::HTTPOK) # rubocop:disable Metrics/LineLength
 
     arr_assignment_groups = JSON.parse(assignment_group_response.body)['result']
@@ -200,9 +200,9 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
           raise Puppet::Error, "servicenow_change_request#make_request called with invalid request type #{type}"
         end
         if oauth_token.unwrap.to_s.strip.empty?
-          request.basic_auth(username, password.unwrap) # password.unwrap when Sensitive
+          request.basic_auth(username, password.unwrap.delete_prefix('"').delete_suffix('"'))
         else
-          request['Authorization'] = "Bearer #{oauth_token.unwrap}"
+          request['Authorization'] = "Bearer #{oauth_token.unwrap.delete_prefix('"').delete_suffix('"')}"
         end
         request['Content-Type'] = 'application/json'
         request['Accept'] = 'application/json'

--- a/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
+++ b/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
@@ -200,9 +200,9 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
           raise Puppet::Error, "servicenow_change_request#make_request called with invalid request type #{type}"
         end
         if oauth_token.unwrap.to_s.strip.empty?
-          request.basic_auth(username, password.unwrap.to_s.delete_prefix('"').delete_suffix('"'))
+          request.basic_auth(username, password.unwrap.delete_prefix('"').delete_suffix('"'))
         else
-          request['Authorization'] = "Bearer #{oauth_token.unwrap.to_s.delete_prefix('"').delete_suffix('"')}"
+          request['Authorization'] = "Bearer #{oauth_token.unwrap.delete_prefix('"').delete_suffix('"')}"
         end
         request['Content-Type'] = 'application/json'
         request['Accept'] = 'application/json'

--- a/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
+++ b/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
@@ -5,18 +5,18 @@ require 'json'
 
 Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
   dispatch :servicenow_change_request do
-    required_param 'String',    :endpoint
-    required_param 'Hash',      :proxy
-    required_param 'String',    :username
-    required_param 'Sensitive', :password
-    required_param 'Sensitive', :oauth_token
-    required_param 'Hash',      :report
-    required_param 'String',    :ia_url
-    required_param 'String',    :promote_to_stage_name
-    required_param 'Integer',   :promote_to_stage_id
-    required_param 'String',    :assignment_group
-    required_param 'String',    :connection_alias
-    required_param 'Boolean',   :auto_create_ci
+    required_param 'String',            :endpoint
+    required_param 'Hash',              :proxy
+    required_param 'String',            :username
+    required_param 'Sensitive[String]', :password
+    required_param 'Sensitive[String]', :oauth_token
+    required_param 'Hash',              :report
+    required_param 'String',            :ia_url
+    required_param 'String',            :promote_to_stage_name
+    required_param 'Integer',           :promote_to_stage_id
+    required_param 'String',            :assignment_group
+    required_param 'String',            :connection_alias
+    required_param 'Boolean',           :auto_create_ci
   end
 
   def servicenow_change_request(endpoint, proxy, username, password, oauth_token, report, ia_url, promote_to_stage_name, promote_to_stage_id, assignment_group, connection_alias, auto_create_ci)
@@ -202,7 +202,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
         if oauth_token.unwrap.to_s.strip.empty?
           request.basic_auth(username, password.unwrap) # password.unwrap when Sensitive
         else
-          request['Authorization'] = "Bearer #{oauth_token}"
+          request['Authorization'] = "Bearer #{oauth_token.unwrap}"
         end
         request['Content-Type'] = 'application/json'
         request['Accept'] = 'application/json'

--- a/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
+++ b/files/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
@@ -5,20 +5,21 @@ require 'json'
 
 Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
   dispatch :servicenow_change_request do
-    required_param 'String',  :endpoint
-    required_param 'Hash',    :proxy
-    required_param 'String',  :username
-    required_param 'String',  :password
-    required_param 'Hash',    :report
-    required_param 'String',  :ia_url
-    required_param 'String',  :promote_to_stage_name
-    required_param 'Integer', :promote_to_stage_id
-    required_param 'String',  :assignment_group
-    required_param 'String',  :connection_alias
-    required_param 'Boolean', :auto_create_ci
+    required_param 'String',    :endpoint
+    required_param 'Hash',      :proxy
+    required_param 'String',    :username
+    required_param 'Sensitive', :password
+    required_param 'Sensitive', :oauth_token
+    required_param 'Hash',      :report
+    required_param 'String',    :ia_url
+    required_param 'String',    :promote_to_stage_name
+    required_param 'Integer',   :promote_to_stage_id
+    required_param 'String',    :assignment_group
+    required_param 'String',    :connection_alias
+    required_param 'Boolean',   :auto_create_ci
   end
 
-  def servicenow_change_request(endpoint, proxy, username, password, report, ia_url, promote_to_stage_name, promote_to_stage_id, assignment_group, connection_alias, auto_create_ci)
+  def servicenow_change_request(endpoint, proxy, username, password, oauth_token, report, ia_url, promote_to_stage_name, promote_to_stage_id, assignment_group, connection_alias, auto_create_ci)
     # Map facts to populate when auto-creating CI's
     fact_map = {
       # PuppetDB fact => ServiceNow CI field
@@ -39,7 +40,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
     description = CGI.escape(descr).gsub(%r{\+}, '%20')
     short_description = CGI.escape("Puppet Code - '#{report['scm']['description']}' to stage '#{promote_to_stage_name}'").gsub(%r{\+}, '%20')
     request_uri = "#{endpoint}/api/sn_chg_rest/v1/change/normal?category=Puppet%20Code&short_description=#{short_description}&description=#{description}"
-    request_response = make_request(request_uri, :post, proxy, username, password)
+    request_response = make_request(request_uri, :post, proxy, username, password, oauth_token)
     raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{request_response.code} #{request_response.body}" unless request_response.is_a?(Net::HTTPSuccess)
 
     changereq = JSON.parse(request_response.body)
@@ -49,7 +50,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
     report['notes'].each do |ia|
       ia['IA_node_reports'].each_key do |node|
         ci_req_uri = "#{endpoint}/api/now/table/cmdb_ci?sysparm_query=name=#{node}"
-        ci_req_response = make_request(ci_req_uri, :get, proxy, username, password)
+        ci_req_response = make_request(ci_req_uri, :get, proxy, username, password, oauth_token)
         raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{ci_req_response.code} #{ci_req_response.body}" unless ci_req_response.is_a?(Net::HTTPOK)
 
         ci = JSON.parse(ci_req_response.body)
@@ -87,7 +88,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
           end
           # Make the API call
           new_ci_uri = "#{endpoint}/api/now/table/cmdb_ci_server"
-          new_ci_response = make_request(new_ci_uri, :post, proxy, username, password, fact_payload)
+          new_ci_response = make_request(new_ci_uri, :post, proxy, username, password, oauth_token, fact_payload)
           raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{new_ci_response.code} #{new_ci_response.body}" unless new_ci_response.is_a?(Net::HTTPSuccess)
 
           # Grab the response to push the sys_id to the array_of_cis
@@ -104,14 +105,14 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
       assoc_ci_uri = "#{endpoint}/api/sn_chg_rest/v1/change/#{changereq['result']['sys_id']['value']}/ci"
       payload = { 'cmdb_ci_sys_ids' => array_of_cis.join(','), 'association_type' => 'affected' }
       # This next request will fail on ServiceNow versions older than New York, if so we fallback to the old task_ci mechanism
-      assoc_ci_response = make_request(assoc_ci_uri, :post, proxy, username, password, payload)
+      assoc_ci_response = make_request(assoc_ci_uri, :post, proxy, username, password, oauth_token, payload)
       if assoc_ci_response.is_a?(Net::HTTPSuccess)
         # This is New York or newer, continue to process response
         assoc_ci_worker = JSON.parse(assoc_ci_response.body)
         assoc_ci_worker_uri = "#{endpoint}/api/sn_chg_rest/change/worker/#{assoc_ci_worker['result']['worker']['sysId']}"
         while assoc_ci_worker['result']['state']['value'] < 3
           sleep 3
-          assoc_ci_response = make_request(assoc_ci_worker_uri, :get, proxy, username, password)
+          assoc_ci_response = make_request(assoc_ci_worker_uri, :get, proxy, username, oauth_token, password)
           assoc_ci_worker = JSON.parse(assoc_ci_response.body)
         end
         raise Puppet::Error, "Failed to associate CI's, got these error(s): #{assoc_ci_worker['result']['messages']['errorMessages']}" unless assoc_ci_worker['result']['state']['value'] == 3
@@ -120,7 +121,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
         array_of_cis.each do |ci|
           task_ci_uri = "#{endpoint}/api/now/table/task_ci"
           task_ci_payload = { 'ci_item' => ci, 'task' => changereq['result']['sys_id']['value'] }
-          task_ci_response = make_request(task_ci_uri, :post, proxy, username, password, task_ci_payload)
+          task_ci_response = make_request(task_ci_uri, :post, proxy, username, password, oauth_token, task_ci_payload)
           raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{task_ci_response.code} #{task_ci_response.body}" unless task_ci_response.is_a?(Net::HTTPSuccess)
         end
       else
@@ -152,7 +153,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
 
     # Get sys_id of given assignment_group
     assignment_group_url = "#{endpoint}/api/now/table/sys_user_group?sysparm_query=name=#{assignment_group}"
-    assignment_group_response = make_request(assignment_group_url, :get, proxy, username, password)
+    assignment_group_response = make_request(assignment_group_url, :get, proxy, username, oauth_token, password)
     raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{assignment_group_response.code} #{assignment_group_response.body}" unless assignment_group_response.is_a?(Net::HTTPOK) # rubocop:disable Metrics/LineLength
 
     arr_assignment_groups = JSON.parse(assignment_group_response.body)['result']
@@ -172,11 +173,11 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
       data[:risk] = bln_ia_safe_verdict ? 4.0 : 2.0   # 2.0 = High / 3.0 = Medium / 4.0 = Low
     end
 
-    change_req_url_res = make_request(change_req_url, :patch, proxy, username, password, payload)
+    change_req_url_res = make_request(change_req_url, :patch, proxy, username, password, oauth_token, payload)
     raise Puppet::Error, "Received unexpected response from the ServiceNow endpoint: #{change_req_url_res.code} #{change_req_url_res.body}" unless change_req_url_res.is_a?(Net::HTTPSuccess)
   end
 
-  def make_request(endpoint, type, proxy, username, password, payload = nil)
+  def make_request(endpoint, type, proxy, username, password, oauth_token, payload = nil)
     uri = URI.parse(endpoint)
     max_attempts = 3
     attempts = 0
@@ -198,13 +199,17 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
         else
           raise Puppet::Error, "servicenow_change_request#make_request called with invalid request type #{type}"
         end
-        request.basic_auth(username, password)
+        if oauth_token.unwrap.to_s.strip.empty?
+          request.basic_auth(username, password.unwrap) # password.unwrap when Sensitive
+        else
+          request['Authorization'] = "Bearer #{oauth_token}"
+        end
         request['Content-Type'] = 'application/json'
         request['Accept'] = 'application/json'
         if proxy['enabled'] == true
           proxy_conn = Net::HTTP::Proxy(
             proxy['host'],
-            proxy['port']
+            proxy['port'],
           )
           response = proxy_conn.start(uri.host, uri.port, :use_ssl => (uri.scheme == 'https')) do |http|
             http.read_timeout = 60

--- a/files/deployments/plans/servicenow_integration.pp
+++ b/files/deployments/plans/servicenow_integration.pp
@@ -1,8 +1,8 @@
 plan deployments::servicenow_integration(
   String $snow_endpoint,
   String $snow_username = '',
-  Sensitive[String] $snow_password = Sensitive(''),
-  Sensitive[String] $snow_oauth_token = Sensitive(''),
+  Sensitive $snow_password = Sensitive(''),
+  Sensitive $snow_oauth_token = Sensitive(''),
   String $stage_to_promote_to = undef,
   Optional[Integer] $max_changes_per_node = 10,
   Optional[String] $report_stage = 'Impact Analysis',

--- a/files/deployments/plans/servicenow_integration.pp
+++ b/files/deployments/plans/servicenow_integration.pp
@@ -1,7 +1,8 @@
 plan deployments::servicenow_integration(
   String $snow_endpoint,
-  String $snow_username,
-  String $snow_password,
+  String $snow_username = '',
+  Sensitive[String] $snow_password = Sensitive(''),
+  Sensitive[String] $snow_oauth_token = Sensitive(''),
   String $stage_to_promote_to = undef,
   Optional[Integer] $max_changes_per_node = 10,
   Optional[String] $report_stage = 'Impact Analysis',
@@ -127,6 +128,7 @@ plan deployments::servicenow_integration(
     $proxy,
     $snow_username,
     $snow_password,
+    $snow_oauth_token,
     $report,
     $ia_url,
     $stage_to_promote_to,

--- a/lib/puppet/functions/servicenow_change_requests/make_request.rb
+++ b/lib/puppet/functions/servicenow_change_requests/make_request.rb
@@ -38,7 +38,7 @@ Puppet::Functions.create_function(:'servicenow_change_requests::make_request') d
         if oauth_token.unwrap.to_s.strip.empty?
           request.basic_auth(username, password.unwrap) # password.unwrap when Sensitive
         else
-          request['Authorization'] = "Bearer #{oauth_token}"
+          request['Authorization'] = "Bearer #{oauth_token.unwrap}"
         end
         request['Content-Type'] = 'application/json'
         request['Accept'] = 'application/json'

--- a/lib/puppet/functions/servicenow_change_requests/make_request.rb
+++ b/lib/puppet/functions/servicenow_change_requests/make_request.rb
@@ -8,11 +8,12 @@ Puppet::Functions.create_function(:'servicenow_change_requests::make_request') d
     required_param 'String', :type
     required_param 'Hash', :proxy
     required_param 'String', :username
-    required_param 'String', :password # 'Sensitive[String]' when Sensitive
+    required_param 'Sensitive[String]', :password
+    required_param 'Sensitive[String]', :oauth_token
     optional_param 'Hash', :payload
   end
 
-  def make_request(endpoint, type, proxy, username, password, payload = nil)
+  def make_request(endpoint, type, proxy, username, password, oauth_token, payload = nil)
     uri = URI.parse(endpoint)
     max_attempts = 3
     attempts = 0
@@ -34,7 +35,11 @@ Puppet::Functions.create_function(:'servicenow_change_requests::make_request') d
         else
           raise Puppet::Error, "servicenow_change_request#make_request called with invalid request type #{type}"
         end
-        request.basic_auth(username, password) # password.unwrap when Sensitive
+        if oauth_token.unwrap.to_s.strip.empty?
+          request.basic_auth(username, password.unwrap) # password.unwrap when Sensitive
+        else
+          request['Authorization'] = "Bearer #{oauth_token}"
+        end
         request['Content-Type'] = 'application/json'
         request['Accept'] = 'application/json'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-servicenow_change_requests",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "author": "puppetlabs",
   "summary": "Automate change requests in ServiceNow from CD4PE pipelines",
   "license": "Apache-2.0",

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -8,8 +8,10 @@
 #   FQDN of your ServiceNow instance. Only specify the FQDN, do not specify https://
 # @param [String] admin_user
 #   Username of the account in ServiceNow that has permissions to create objects
-# @param [String] admin_password
+# @param [Sensitive[String]] admin_password
 #   Password of the account in ServiceNow that has permissions to create objects
+# @param [Sensitive[String]] oauth_token
+#   OAuth token to access ServiceNow, instead of using username & password
 # @param [String] cd4pe_endpoint
 #   FQDN of your CD4PE instance. Only specify the FQDN, do not specify https://
 # @param [Optional[Boolean]] cd4pe_https

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -25,8 +25,9 @@
 # 
 plan servicenow_change_requests::prep_servicenow(
   String $snow_endpoint,
-  String $admin_user,
-  String $admin_password,
+  String $admin_user = '',
+  Sensitive[String] $admin_password = Sensitive(''),
+  Sensitive[String] $oauth_token = Sensitive(''),
   String $cd4pe_endpoint,
   Optional[Boolean] $cd4pe_https = true,
   Optional[Integer] $cd4pe_port = undef,
@@ -59,7 +60,7 @@ plan servicenow_change_requests::prep_servicenow(
 
   # Connect to ServiceNow and validate credentials
   $cred_uri = "${_snow_endpoint}/api/now/table/sys_user_group?sysparm_limit=1"
-  $cred_result = servicenow_change_requests::make_request($cred_uri, 'get', $proxy, $admin_user, $admin_password)
+  $cred_result = servicenow_change_requests::make_request($cred_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $cred_result['code'] == 200 {
     fail("Unable to authenticate to ServiceNow! Got error ${cred_result['code']} with message ${cred_result['body']}")
   }
@@ -69,7 +70,7 @@ plan servicenow_change_requests::prep_servicenow(
 
   # Check if 'Puppet Code' is listed as a change category
   $category_check_uri = "${_snow_endpoint}/api/now/table/sys_choice?sysparm_query=name=change_request&element=category&language=en"
-  $category_check_result = servicenow_change_requests::make_request($category_check_uri, 'get', $proxy, $admin_user, $admin_password)
+  $category_check_result = servicenow_change_requests::make_request($category_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $category_check_result['code'] == 200 {
     fail("Unable to request change categories! Got error ${category_check_result['code']} with message ${category_check_result['body']}")
   }
@@ -97,7 +98,7 @@ plan servicenow_change_requests::prep_servicenow(
       'element'  => 'category'
     }
     $new_category_uri = "${_snow_endpoint}/api/now/table/sys_choice"
-    $new_category_result = servicenow_change_requests::make_request($new_category_uri, 'post', $proxy, $admin_user, $admin_password, $new_category)
+    $new_category_result = servicenow_change_requests::make_request($new_category_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_category)
     unless $new_category_result['code'] == 201 {
       fail("Unable to add Change request category 'Puppet Code'! Got error ${new_category_result['code']} with message ${new_category_result['body']}") # lint:ignore:140chars
     }
@@ -109,7 +110,7 @@ plan servicenow_change_requests::prep_servicenow(
 
   # Check if 'Puppet - Promote code after approval' is listed as a business rule
   $rule_check_uri = "${_snow_endpoint}/api/now/table/sys_script?sysparm_query=name=Puppet%20-%20Promote%20code%20after%20approval"
-  $rule_check_result = servicenow_change_requests::make_request($rule_check_uri, 'get', $proxy, $admin_user, $admin_password)
+  $rule_check_result = servicenow_change_requests::make_request($rule_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $rule_check_result['code'] == 200 {
     fail("Unable to request business rules! Got error ${rule_check_result['code']} with message ${rule_check_result['body']}")
   }
@@ -151,7 +152,7 @@ plan servicenow_change_requests::prep_servicenow(
       'role_conditions'   => '',
     }
     $new_rule_uri = "${_snow_endpoint}/api/now/table/sys_script"
-    $new_rule_result = servicenow_change_requests::make_request($new_rule_uri, 'post', $proxy, $admin_user, $admin_password, $new_rule)
+    $new_rule_result = servicenow_change_requests::make_request($new_rule_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_rule)
     unless $new_rule_result['code'] == 201 {
       fail("Unable to add business rule 'Puppet - Promote code after approval'! Got error ${new_rule_result['code']} with message ${new_rule_result['body']}") # lint:ignore:140chars
     }
@@ -173,7 +174,7 @@ plan servicenow_change_requests::prep_servicenow(
       $rule_script = epp("servicenow_change_requests/${br_version}/business_rule_script.js")
       $updated_rule = { 'script' => $rule_script }
       $rule_uri = "${_snow_endpoint}/api/now/table/sys_script/${rule_check_result['body'][0]['sys_id']}"
-      $rule_result = servicenow_change_requests::make_request($rule_uri, 'patch', $proxy, $admin_user, $admin_password, $updated_rule)
+      $rule_result = servicenow_change_requests::make_request($rule_uri, 'patch', $proxy, $admin_user, $admin_password, $oauth_token, $updated_rule)
       unless $rule_result['code'] == 200 {
         fail("Unable to update business rule 'Puppet - Promote code after approval'! Got error ${rule_result['code']} with message ${rule_result['body']}") # lint:ignore:140chars
       }
@@ -196,7 +197,7 @@ plan servicenow_change_requests::prep_servicenow(
 
   # Check if connection alias is already present
   $alias_check_uri = "${_snow_endpoint}/api/now/table/sys_alias?sysparm_query=name=${alias_name}"
-  $alias_check_result = servicenow_change_requests::make_request($alias_check_uri, 'get', $proxy, $admin_user, $admin_password)
+  $alias_check_result = servicenow_change_requests::make_request($alias_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $alias_check_result['code'] == 200 {
     fail("Unable to request connection aliases! Got error ${alias_check_result['code']} with message ${alias_check_result['body']}")
   }
@@ -212,7 +213,7 @@ plan servicenow_change_requests::prep_servicenow(
       'name'                   => $alias_name,
     }
     $new_alias_uri = "${_snow_endpoint}/api/now/table/sys_alias"
-    $new_alias_result = servicenow_change_requests::make_request($new_alias_uri, 'post', $proxy, $admin_user, $admin_password, $new_alias)
+    $new_alias_result = servicenow_change_requests::make_request($new_alias_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_alias)
     unless $new_alias_result['code'] == 201 {
       fail("Unable to add connection alias '${alias_name}'! Got error ${new_alias_result['code']} with message ${new_alias_result['body']}") # lint:ignore:140chars
     }
@@ -226,7 +227,7 @@ plan servicenow_change_requests::prep_servicenow(
 
   # Check if credential is already present
   $cred_check_uri = "${_snow_endpoint}/api/now/table/discovery_credentials?sysparm_query=name=${cred_name}"
-  $cred_check_result = servicenow_change_requests::make_request($cred_check_uri, 'get', $proxy, $admin_user, $admin_password)
+  $cred_check_result = servicenow_change_requests::make_request($cred_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $cred_check_result['code'] == 200 {
     fail("Unable to request credentials! Got error ${cred_check_result['code']} with message ${cred_check_result['body']}")
   }
@@ -244,7 +245,7 @@ plan servicenow_change_requests::prep_servicenow(
       'sys_class_name'          => 'basic_auth_credentials',
     }
     $new_cred_uri = "${_snow_endpoint}/api/now/table/discovery_credentials"
-    $new_cred_result = servicenow_change_requests::make_request($new_cred_uri, 'post', $proxy, $admin_user, $admin_password, $new_cred)
+    $new_cred_result = servicenow_change_requests::make_request($new_cred_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_cred)
     unless $new_cred_result['code'] == 201 {
       fail("Unable to add credential '${cred_name}'! Got error ${new_cred_result['code']} with message ${new_cred_result['body']}") # lint:ignore:140chars
     }
@@ -257,7 +258,7 @@ plan servicenow_change_requests::prep_servicenow(
 
   # Check if connection is already present
   $conn_check_uri = "${_snow_endpoint}/api/now/table/sys_connection?sysparm_query=name=${conn_name}"
-  $conn_check_result = servicenow_change_requests::make_request($conn_check_uri, 'get', $proxy, $admin_user, $admin_password)
+  $conn_check_result = servicenow_change_requests::make_request($conn_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $conn_check_result['code'] == 200 {
     fail("Unable to request connections! Got error ${conn_check_result['code']} with message ${conn_check_result['body']}")
   }
@@ -279,7 +280,7 @@ plan servicenow_change_requests::prep_servicenow(
       'connection_timeout' => '0',
     }
     $new_conn_uri = "${_snow_endpoint}/api/now/table/sys_connection"
-    $new_conn_result = servicenow_change_requests::make_request($new_conn_uri, 'post', $proxy, $admin_user, $admin_password, $new_conn)
+    $new_conn_result = servicenow_change_requests::make_request($new_conn_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_conn)
     unless $new_conn_result['code'] == 201 {
       fail("Unable to add connection '${conn_name}'! Got error ${new_conn_result['code']} with message ${new_conn_result['body']}") # lint:ignore:140chars
     }


### PR DESCRIPTION
**Features**
- Adds support for OAuth authentication against ServiceNow
- Uses the Sensitive datatype for password & OAuth token inputs, which will mask the input in PE and CD4PE
- Adds official support for ServiceNow Rome
- Removes official support for CD4PE 3.x