### PR TITLE
Params updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To ensure we can automate change requests, some things need to be added to Servi
 A single plan takes care of setting this up. To run the plan, go to the `Plans` section in the left navigation bar in Puppet Enterprise. In the "Run a plan" screen, select the `servicenow_change_requests::prep_servicenow` from the Plan dropdown list. If the plan is not listed, ensure that this module has been added to the Puppetfile of your control repo, and that you have performed a code deployment to your production environment.
 
 The plan requires 2 parameters + authentication info, and has 3 more optional parameters for specific use cases. The 2 required parameters are:
-* `snow_endpoint`:  The reachable FQDN of the ServiceNow instance (just the name is sufficient)
+* `now_endpoint`:  The reachable FQDN of the ServiceNow instance (just the name is sufficient)
 * `cd4pe_endpoint`: The publicly reachable FQDN of the CD4PE server (just the name, not the full URL)
 
 For authentication info, either a username + password must be set, or a valid OAuth token can be used:
@@ -48,13 +48,13 @@ For authentication info, either a username + password must be set, or a valid OA
 * `oauth_token`:    An OAuth token for accessing ServiceNow, instead of using username + password
 
 For example, to configure the ServiceNow instance `https://dev365937.service-now.com` to integrate with a CD4PE server at `https://puppet-cd4pe.mycompany.com`, specify the parameters as follows:
-* `snow_endpoint  = dev365937.service-now.com`
+* `now_endpoint  = dev365937.service-now.com`
 * `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
 * `admin_user     = admin`
 * `admin_password = <password>`
 
 or, with an OAuth token:
-* `snow_endpoint  = dev365937.service-now.com`
+* `now_endpoint  = dev365937.service-now.com`
 * `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
 * `oauth_token    = <token>`
 
@@ -66,7 +66,7 @@ If you are running a CD4PE version lower than 4.5.0, you will need to set the `b
 Omit this parameter when you are running CD4PE 4.5.0 or above, which will install version 0.2.3 of the Business Rule, which is compatible with CD4PE 4.5.0.
 
 The optional parameters `cd4pe_https` and `cd4pe_port` can be used to connect to a CD4PE server on a different port, or via http. For example, to configure the ServiceNow instance `https://dev365937.service-now.com` to integrate with a CD4PE server at `http://puppet-cd4pe.mycompany.com:8080`, specify the parameters as follows:
-* `snow_endpoint  = dev365937.service-now.com`
+* `now_endpoint  = dev365937.service-now.com`
 * `admin_user     = admin`
 * `admin_password = <password>`
 * `cd4pe_endpoint = puppet-cd4pe.mycompany.com`
@@ -123,10 +123,10 @@ Once the custom deployment policy is available, add it to your `master` pipeline
 4. Click the `Custom deployment policies` radio button
 5. Select the `deployments::servicenow_integration` policy
 6. Set the parameters for the policy:
-   * `snow_endpoint`: the FQDN of your ServiceNow instance (e.g. `dev-365937.service-now.com`)
-   * `snow_username`: the username to authenticate with ServiceNow (e.g. `admin`)
-   * `snow_password`: the password to authenticate with ServiceNow (e.g. `P@ssw0rd!`)
-   * `snow_oauth_token`: an OAuth token for ServiceNow, instead of using username + password (if you set an OAuth token, it will be used instead of username + password)
+   * `now_endpoint`: the FQDN of your ServiceNow instance (e.g. `dev-365937.service-now.com`)
+   * `now_username`: the username to authenticate with ServiceNow (e.g. `admin`)
+   * `now_password`: the password to authenticate with ServiceNow (e.g. `P@ssw0rd!`)
+   * `now_oauth_token`: an OAuth token for ServiceNow, instead of using username + password (if you set an OAuth token, it will be used instead of username + password)
    * `stage_to_promote_to`: the name of the stage to promote to, when approved (e.g. `Deploy to Production`)
 7. If desired, set (some of the) optional parameters for the policy:
    * `max_changes_per_node`: how many resources per node may change before CD4PE recommends this code change warrants more scrutiny (defaults to `10`)

--- a/files/deployments/plans/servicenow_integration.pp
+++ b/files/deployments/plans/servicenow_integration.pp
@@ -1,8 +1,8 @@
 plan deployments::servicenow_integration(
-  String $snow_endpoint,
-  String $snow_username = '',
-  Sensitive $snow_password = Sensitive(''),
-  Sensitive $snow_oauth_token = Sensitive(''),
+  String $now_endpoint,
+  String $now_username = '',
+  Sensitive $now_password = Sensitive(''),
+  Sensitive $now_oauth_token = Sensitive(''),
   String $stage_to_promote_to = undef,
   Optional[Integer] $max_changes_per_node = 10,
   Optional[String] $report_stage = 'Impact Analysis',
@@ -23,13 +23,13 @@ plan deployments::servicenow_integration(
     'MODULE' => $module_name
   }
 
-  # Parse $snow_endpoint
-  if $snow_endpoint == undef {
+  # Parse $now_endpoint
+  if $now_endpoint == undef {
     fail_plan('No ServiceNow endpoint specified!', 'no_endpoint_error')
   } else {
-    $_snow_endpoint = $snow_endpoint[0,8] ? {
-      'https://' => $snow_endpoint,
-      default    => "https://${snow_endpoint}"
+    $_now_endpoint = $now_endpoint[0,8] ? {
+      'https://' => $now_endpoint,
+      default    => "https://${now_endpoint}"
     }
   }
 
@@ -124,11 +124,11 @@ plan deployments::servicenow_integration(
   $promote_stage_number = $promote_stage[0]['stageNum']
   # Trigger Change Request workflow in ServiceNow DevOps
   deployments::servicenow_change_request(
-    $_snow_endpoint,
+    $_now_endpoint,
     $proxy,
-    $snow_username,
-    $snow_password,
-    $snow_oauth_token,
+    $now_username,
+    $now_password,
+    $now_oauth_token,
     $report,
     $ia_url,
     $stage_to_promote_to,

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -41,7 +41,7 @@ plan servicenow_change_requests::prep_servicenow(
   # Parse flexible parameters
   $_now_endpoint = $now_endpoint[0,8] ? {
     'https://' => $now_endpoint,
-    default    => "https://${_endpoint}"
+    default    => "https://${now_endpoint}"
   }
 
   unless cd4pe_port {

--- a/plans/prep_servicenow.pp
+++ b/plans/prep_servicenow.pp
@@ -2,9 +2,9 @@
 #   Prepares ServiceNow for the Change Request integration by ensuring all necessary objects exist (Change Category, Business Rule, Connection & Credential objects)
 # 
 # @example
-#   bolt plan run servicenow_change_requests::prep_servicenow snow_endpoint=customer.service-now.com admin_user=admin admin_password=password cd4pe_endpoint=cd4pe.company.local
+#   bolt plan run servicenow_change_requests::prep_servicenow now_endpoint=customer.service-now.com admin_user=admin admin_password=password cd4pe_endpoint=cd4pe.company.local
 # 
-# @param [String] snow_endpoint
+# @param [String] now_endpoint
 #   FQDN of your ServiceNow instance. Only specify the FQDN, do not specify https://
 # @param [String] admin_user
 #   Username of the account in ServiceNow that has permissions to create objects
@@ -26,7 +26,7 @@
 #   If you need to connect via a proxy server, specify its port here
 # 
 plan servicenow_change_requests::prep_servicenow(
-  String $snow_endpoint,
+  String $now_endpoint,
   String $admin_user = '',
   Sensitive[String] $admin_password = Sensitive(''),
   Sensitive[String] $oauth_token = Sensitive(''),
@@ -39,9 +39,9 @@ plan servicenow_change_requests::prep_servicenow(
   Optional[String] $br_version = '0.2.3'
 ){
   # Parse flexible parameters
-  $_snow_endpoint = $snow_endpoint[0,8] ? {
-    'https://' => $snow_endpoint,
-    default    => "https://${snow_endpoint}"
+  $_now_endpoint = $now_endpoint[0,8] ? {
+    'https://' => $now_endpoint,
+    default    => "https://${_endpoint}"
   }
 
   unless cd4pe_port {
@@ -61,17 +61,17 @@ plan servicenow_change_requests::prep_servicenow(
   }
 
   # Connect to ServiceNow and validate credentials
-  $cred_uri = "${_snow_endpoint}/api/now/table/sys_user_group?sysparm_limit=1"
+  $cred_uri = "${_now_endpoint}/api/now/table/sys_user_group?sysparm_limit=1"
   $cred_result = servicenow_change_requests::make_request($cred_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $cred_result['code'] == 200 {
     fail("Unable to authenticate to ServiceNow! Got error ${cred_result['code']} with message ${cred_result['body']}")
   }
   else {
-    out::message("Successfully authenticated to ServiceNow endpoint ${_snow_endpoint}")
+    out::message("Successfully authenticated to ServiceNow endpoint ${_now_endpoint}")
   }
 
   # Check if 'Puppet Code' is listed as a change category
-  $category_check_uri = "${_snow_endpoint}/api/now/table/sys_choice?sysparm_query=name=change_request&element=category&language=en"
+  $category_check_uri = "${_now_endpoint}/api/now/table/sys_choice?sysparm_query=name=change_request&element=category&language=en"
   $category_check_result = servicenow_change_requests::make_request($category_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $category_check_result['code'] == 200 {
     fail("Unable to request change categories! Got error ${category_check_result['code']} with message ${category_check_result['body']}")
@@ -99,7 +99,7 @@ plan servicenow_change_requests::prep_servicenow(
       'value'    => 'Puppet Code',
       'element'  => 'category'
     }
-    $new_category_uri = "${_snow_endpoint}/api/now/table/sys_choice"
+    $new_category_uri = "${_now_endpoint}/api/now/table/sys_choice"
     $new_category_result = servicenow_change_requests::make_request($new_category_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_category)
     unless $new_category_result['code'] == 201 {
       fail("Unable to add Change request category 'Puppet Code'! Got error ${new_category_result['code']} with message ${new_category_result['body']}") # lint:ignore:140chars
@@ -111,7 +111,7 @@ plan servicenow_change_requests::prep_servicenow(
   }
 
   # Check if 'Puppet - Promote code after approval' is listed as a business rule
-  $rule_check_uri = "${_snow_endpoint}/api/now/table/sys_script?sysparm_query=name=Puppet%20-%20Promote%20code%20after%20approval"
+  $rule_check_uri = "${_now_endpoint}/api/now/table/sys_script?sysparm_query=name=Puppet%20-%20Promote%20code%20after%20approval"
   $rule_check_result = servicenow_change_requests::make_request($rule_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $rule_check_result['code'] == 200 {
     fail("Unable to request business rules! Got error ${rule_check_result['code']} with message ${rule_check_result['body']}")
@@ -153,7 +153,7 @@ plan servicenow_change_requests::prep_servicenow(
       'name'              => 'Puppet - Promote code after approval',
       'role_conditions'   => '',
     }
-    $new_rule_uri = "${_snow_endpoint}/api/now/table/sys_script"
+    $new_rule_uri = "${_now_endpoint}/api/now/table/sys_script"
     $new_rule_result = servicenow_change_requests::make_request($new_rule_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_rule)
     unless $new_rule_result['code'] == 201 {
       fail("Unable to add business rule 'Puppet - Promote code after approval'! Got error ${new_rule_result['code']} with message ${new_rule_result['body']}") # lint:ignore:140chars
@@ -175,7 +175,7 @@ plan servicenow_change_requests::prep_servicenow(
       out::message("Business rule 'Puppet - Promote code after approval' is outdated and will be updated...")
       $rule_script = epp("servicenow_change_requests/${br_version}/business_rule_script.js")
       $updated_rule = { 'script' => $rule_script }
-      $rule_uri = "${_snow_endpoint}/api/now/table/sys_script/${rule_check_result['body'][0]['sys_id']}"
+      $rule_uri = "${_now_endpoint}/api/now/table/sys_script/${rule_check_result['body'][0]['sys_id']}"
       $rule_result = servicenow_change_requests::make_request($rule_uri, 'patch', $proxy, $admin_user, $admin_password, $oauth_token, $updated_rule)
       unless $rule_result['code'] == 200 {
         fail("Unable to update business rule 'Puppet - Promote code after approval'! Got error ${rule_result['code']} with message ${rule_result['body']}") # lint:ignore:140chars
@@ -198,7 +198,7 @@ plan servicenow_change_requests::prep_servicenow(
   }
 
   # Check if connection alias is already present
-  $alias_check_uri = "${_snow_endpoint}/api/now/table/sys_alias?sysparm_query=name=${alias_name}"
+  $alias_check_uri = "${_now_endpoint}/api/now/table/sys_alias?sysparm_query=name=${alias_name}"
   $alias_check_result = servicenow_change_requests::make_request($alias_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $alias_check_result['code'] == 200 {
     fail("Unable to request connection aliases! Got error ${alias_check_result['code']} with message ${alias_check_result['body']}")
@@ -214,7 +214,7 @@ plan servicenow_change_requests::prep_servicenow(
       'multiple_connections'   => 'false',
       'name'                   => $alias_name,
     }
-    $new_alias_uri = "${_snow_endpoint}/api/now/table/sys_alias"
+    $new_alias_uri = "${_now_endpoint}/api/now/table/sys_alias"
     $new_alias_result = servicenow_change_requests::make_request($new_alias_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_alias)
     unless $new_alias_result['code'] == 201 {
       fail("Unable to add connection alias '${alias_name}'! Got error ${new_alias_result['code']} with message ${new_alias_result['body']}") # lint:ignore:140chars
@@ -228,7 +228,7 @@ plan servicenow_change_requests::prep_servicenow(
   }
 
   # Check if credential is already present
-  $cred_check_uri = "${_snow_endpoint}/api/now/table/discovery_credentials?sysparm_query=name=${cred_name}"
+  $cred_check_uri = "${_now_endpoint}/api/now/table/discovery_credentials?sysparm_query=name=${cred_name}"
   $cred_check_result = servicenow_change_requests::make_request($cred_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $cred_check_result['code'] == 200 {
     fail("Unable to request credentials! Got error ${cred_check_result['code']} with message ${cred_check_result['body']}")
@@ -246,7 +246,7 @@ plan servicenow_change_requests::prep_servicenow(
       'name'                    => $cred_name,
       'sys_class_name'          => 'basic_auth_credentials',
     }
-    $new_cred_uri = "${_snow_endpoint}/api/now/table/discovery_credentials"
+    $new_cred_uri = "${_now_endpoint}/api/now/table/discovery_credentials"
     $new_cred_result = servicenow_change_requests::make_request($new_cred_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_cred)
     unless $new_cred_result['code'] == 201 {
       fail("Unable to add credential '${cred_name}'! Got error ${new_cred_result['code']} with message ${new_cred_result['body']}") # lint:ignore:140chars
@@ -259,7 +259,7 @@ plan servicenow_change_requests::prep_servicenow(
   }
 
   # Check if connection is already present
-  $conn_check_uri = "${_snow_endpoint}/api/now/table/sys_connection?sysparm_query=name=${conn_name}"
+  $conn_check_uri = "${_now_endpoint}/api/now/table/sys_connection?sysparm_query=name=${conn_name}"
   $conn_check_result = servicenow_change_requests::make_request($conn_check_uri, 'get', $proxy, $admin_user, $admin_password, $oauth_token)
   unless $conn_check_result['code'] == 200 {
     fail("Unable to request connections! Got error ${conn_check_result['code']} with message ${conn_check_result['body']}")
@@ -281,7 +281,7 @@ plan servicenow_change_requests::prep_servicenow(
       'name'               => $conn_name,
       'connection_timeout' => '0',
     }
-    $new_conn_uri = "${_snow_endpoint}/api/now/table/sys_connection"
+    $new_conn_uri = "${_now_endpoint}/api/now/table/sys_connection"
     $new_conn_result = servicenow_change_requests::make_request($new_conn_uri, 'post', $proxy, $admin_user, $admin_password, $oauth_token, $new_conn)
     unless $new_conn_result['code'] == 201 {
       fail("Unable to add connection '${conn_name}'! Got error ${new_conn_result['code']} with message ${new_conn_result['body']}") # lint:ignore:140chars


### PR DESCRIPTION
Updated params that used 'snow' to use 'now' which is the preferred ServiceNow shorthand. 
This was tested in a fresh env with PE version 2021.1.0 and ServiceNow release Rome and CD4PE version 4.8.2. 
Testing Steps: 
Ran a servicenow_change_requests::prep_servicenow plan from PE 
Updated CD4PE credentials in ServiceNow 
Created a CD4PE pipeline that included a ServiceNow Change Request stage 
Approved change request in ServiceNow and triggered CD4PE promote event 