### PR TITLE
v0.4.1: Create CSV on empty IA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.4.1
+**Bugfixes**
+- Ensures that when IA runs but returns no changes, a CSV export still results in an attachment to the ServiceNow Change Request, containing the text `Impact analysis did not detect any resource changes`.
+
 ## Release 0.4.0
 
 **Features**

--- a/files/deployments/plans/servicenow_integration.pp
+++ b/files/deployments/plans/servicenow_integration.pp
@@ -111,14 +111,18 @@ plan deployments::servicenow_integration(
     if $attach_ia_csv {
       cd4pe_deployments::create_custom_deployment_event('Exporting Impact Analysis results to CSV...')
       $ia_csv_result = cd4pe_deployments::get_impact_analysis_csv($impact_analysis_id)
-      $ia_csv = cd4pe_deployments::evaluate_result($ia_csv_result)
+      $ia_csv_hash = cd4pe_deployments::evaluate_result($ia_csv_result)
+      $ia_csv = $ia_csv_hash['csv'] ? {
+        ''      => {'csv'=>'Impact analysis did not detect any resource changes'},
+        default => $ia_csv_hash,
+      }
     } else {
       $ia_csv = {'csv'=>''}
     }
   } else {
     $ia_envs_report = Tuple({})
     $ia_url = 'No Impact Analysis performed'
-    $ia_csv = {'csv'=>'Impact analysis didn\'t detect any resource changes'}
+    $ia_csv = {'csv'=>'No Impact Analysis performed'}
   }
 
   # Combine all reports into a single hash

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-servicenow_change_requests",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "puppetlabs",
   "summary": "Automate change requests in ServiceNow from CD4PE pipelines",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR ensures that when IA runs but returns no changes, a CSV export still results in an attachment to the ServiceNow Change Request, containing the text `Impact analysis did not detect any resource changes`.